### PR TITLE
Adds option for additional tags

### DIFF
--- a/RaygunCore/RaygunOptions.cs
+++ b/RaygunCore/RaygunOptions.cs
@@ -41,6 +41,11 @@ namespace RaygunCore
 		};
 
 		/// <summary>
+		/// Gets or sets tags for all error messages sent to the Raygun endpoint.
+		/// </summary>
+		public IList<string>? Tags { get; set; }
+
+		/// <summary>
 		/// Gets or sets if errors for local requests are skipped.
 		/// Works only when Raygun HTTP services registered.
 		/// Default <c>false</c>.

--- a/RaygunCore/Services/DefaultRaygunClient.cs
+++ b/RaygunCore/Services/DefaultRaygunClient.cs
@@ -36,6 +36,11 @@ namespace RaygunCore.Services
 		public async Task SendAsync(string message, Exception? exception, RaygunSeverity? severity = null, IList<string>? tags = null, IDictionary<string, object>? customData = null)
 		{
 			IEnumerable<Exception?> exceptions = exception?.StripWrapperExceptions(_options.WrapperExceptions) ?? Enumerable.Repeat<Exception?>(null, 1);
+            tags = tags == null
+                ? _options.Tags
+                : _options.Tags == null
+                    ? tags
+                    : tags.Concat(_options.Tags).Distinct().ToList();
 			foreach (var ex in exceptions)
 			{
 				if (ShouldSend(message, ex))


### PR DESCRIPTION
This PR allows to configure additional tags for all messages send to the Raygun endpoint.
E.g. depending on your environment, the option to add `Staging` or `Production` would be quite useful.